### PR TITLE
Add subscription package

### DIFF
--- a/pkg/payment/payment.go
+++ b/pkg/payment/payment.go
@@ -1,0 +1,35 @@
+package payment
+
+type Payment struct {
+	Result bool
+	// I think putting the HTTP status code here is bad practice, as it's related to the underlying web server and has
+	// nothing to do with subscriptions. But for the sake of this mock server, it's easier to put it here.
+	StatusCode int
+}
+
+var count = 0
+
+func shouldSucceed() bool {
+	// This function returns false every other time it's called, so we can fail 50% of the requests.
+
+	// The current state of this function does not allow this app to be stateless, as the value of count is hold in memory.
+	// Therefore we cannot cluster this app. Make sure replicaCount is set to 1 until the app is made stateless.
+	count++
+	if count%2 != 0 {
+		return true
+	}
+	return false
+}
+
+func Pay() Payment {
+	// We should not rely solely on Antaeus, and we need a mechanism to make sure Antaeus is not requesting > 1 payment
+	// for the same invoice
+	if shouldSucceed(){
+		p := Payment{true, 201}
+		return p
+	}
+	// Ideally, APIs should not return 500 if we are failing something on purpose, but I could not think of a better
+	// status code.
+	p := Payment{false, 500}
+	return p
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,11 +1,12 @@
 package server
 
 import (
+	"github.com/fardin01/fardin-payment-provider/pkg/payment"
 	"github.com/gin-gonic/gin"
 	"time"
 )
 
-func Start()  {
+func Start() {
 	r := gin.Default()
 
 	r.GET("/", func(c *gin.Context) {
@@ -16,7 +17,7 @@ func Start()  {
 
 	r.GET("/readiness", func(c *gin.Context) {
 		// Pretending that it takes 10 seconds for the app to start and to be ready to server requests.
-		// In production, this should fail if code/app is not ready e.g. if it fails to connect to a database or dependency.
+		// In production, this should fail if code/app is not ready e.g. if it fails to connect to a database or a dependency.
 		time.Sleep(10 * time.Second)
 		c.JSON(200, gin.H{
 			"message": "Ready",
@@ -30,9 +31,13 @@ func Start()  {
 		})
 	})
 
-	r.POST("/rest/v1/payments/", func(c *gin.Context) {
-		c.JSON(201, gin.H{
-			"result": true,
+	r.POST("/rest/v1/payments/pay", func(c *gin.Context) {
+		// payInvoices function in Antaeus calls this endpoint in a loop, which can very easily overload this server and
+		// cause it to crash/suffer performance issues (not scalable). In production, This payment provider server should
+		// offer a batch pay API, so Antaeus can pay n invoices with one API call.
+		s := payment.Pay()
+		c.JSON(s.StatusCode, gin.H{
+			"result": s.Result,
 		})
 	})
 


### PR DESCRIPTION
This commit adds subscription package which is responsible for deciding
whether a subscription/invoice can be paid or not.

The endpoint fails every other requests that it receives. As far as I
understood from Antaeus README, payment provider should fail 50% of the
requests, but Antaeus stops making the requests (exists loop) once one
invoice is failed to be paid, so without changing the client code
(Antaeus) we cannot make 50% of *all* the requests fail.