### PR TITLE
Add Helm chart

### DIFF
--- a/kubernetes/.helmignore
+++ b/kubernetes/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fardin-payment-provider
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 1.16.0

--- a/kubernetes/templates/_helpers.tpl
+++ b/kubernetes/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fardin-payment-provider.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fardin-payment-provider.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fardin-payment-provider.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fardin-payment-provider.labels" -}}
+helm.sh/chart: {{ include "fardin-payment-provider.chart" . }}
+{{ include "fardin-payment-provider.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fardin-payment-provider.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fardin-payment-provider.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fardin-payment-provider.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fardin-payment-provider.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/kubernetes/templates/deployment.yaml
+++ b/kubernetes/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fardin-payment-provider.fullname" . }}
+  labels:
+    {{- include "fardin-payment-provider.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fardin-payment-provider.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fardin-payment-provider.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fardin-payment-provider.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /liveliness
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "fardin-payment-provider.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "fardin-payment-provider.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/kubernetes/templates/service.yaml
+++ b/kubernetes/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fardin-payment-provider.fullname" . }}
+  labels:
+    {{- include "fardin-payment-provider.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fardin-payment-provider.selectorLabels" . | nindent 4 }}

--- a/kubernetes/templates/serviceaccount.yaml
+++ b/kubernetes/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fardin-payment-provider.serviceAccountName" . }}
+  labels:
+    {{- include "fardin-payment-provider.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -1,0 +1,52 @@
+# This application is not clusterable, so keep replicaCount to 1
+replicaCount: 1
+
+image:
+  repository: fardin-payment-provider
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+   limits:
+     cpu: 100m
+     memory: 128Mi
+   requests:
+     cpu: 50m
+     memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pkg/payment/payment.go
+++ b/pkg/payment/payment.go
@@ -1,9 +1,18 @@
 package payment
 
+import (
+	"encoding/json"
+	"fmt"
+	"hash"
+)
+
 type Payment struct {
+	CustomerId int
+	Value float64
+	Currency hash.Hash
 	Result bool
 	// I think putting the HTTP status code here is bad practice, as it's related to the underlying web server and has
-	// nothing to do with subscriptions. But for the sake of this mock server, it's easier to put it here.
+	// nothing to do with payments. But for the sake of this mock server, it's easier to put it here.
 	StatusCode int
 }
 
@@ -18,15 +27,28 @@ func shouldSucceed() bool {
 	return count%2 != 0
 }
 
-func Pay() Payment {
+func Pay(invoice []byte) Payment {
 	// We should not rely solely on Antaeus, and we need a mechanism to make sure Antaeus is not requesting > 1 payment
-	// for the same invoice
+	// for the same invoice. And of course many other validations that I'm not implementing here.
+
+	var payment Payment
+	err := json.Unmarshal(invoice, &payment)
+
+	if err != nil {
+		fmt.Printf("could not unmarshal invoice data: %v", err)
+	}
+
+	fmt.Println("Attempting to pay invoice: ", string(invoice))
 	if shouldSucceed(){
-		p := Payment{true, 201}
-		return p
+		fmt.Printf("Successfully paid invoice for customer with ID: %v and value of %v", payment.CustomerId, payment.Value)
+		payment.Result = true
+		payment.StatusCode = 200
+		return payment
 	}
 	// Ideally, APIs should not return 500 if we are failing something on purpose, but I could not think of a better
 	// status code.
-	p := Payment{false, 500}
-	return p
+	fmt.Printf("Failed to pay invoice for customer with ID: %v and value of %v", payment.CustomerId, payment.Value)
+	payment.Result = false
+	payment.StatusCode = 500
+	return payment
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,11 +17,11 @@ func Start() {
 	})
 
 	r.GET("/readiness", func(c *gin.Context) {
-		// Pretending that it takes 10 seconds for the app to start and to be ready to server requests.
+		// Pretending that it takes 5 seconds for the app to start and to be ready to server requests.
 		// In production, this should fail if code/app is not ready e.g. if it fails to connect to a database or a dependency.
-		time.Sleep(10 * time.Second)
+		time.Sleep(5 * time.Second)
 		c.JSON(200, gin.H{
-			"message": "Ready",
+			"message": "ok",
 		})
 	})
 
@@ -36,7 +36,12 @@ func Start() {
 		// payInvoices function in Antaeus calls this endpoint in a loop, which can very easily overload this server and
 		// cause it to crash/suffer performance issues (not scalable). In production, This payment provider server should
 		// offer a batch pay API, so Antaeus can pay n invoices with one API call.
-		s := payment.Pay()
+		invoice, err := c.GetRawData()
+		if err != nil {
+			fmt.Println("Could not get request body: ", err)
+			return
+		}
+		s := payment.Pay(invoice)
 		c.JSON(s.StatusCode, gin.H{
 			"result": s.Result,
 		})


### PR DESCRIPTION
This commit adds a Helm chart to this repo so that we can deploy it to a
Kubernetes cluster. The chart creates a deployment with 1 pod and a
service objects that redirects traffic to the pod.